### PR TITLE
Browser Refresh - Warn User With Unsaved Content

### DIFF
--- a/components/document-editor.tsx
+++ b/components/document-editor.tsx
@@ -27,6 +27,10 @@ interface EditorProps {
   }
 }
 
+/**
+ * Used by parent components to determine farther up hierarchy
+ * to warn user from leaving page without saving
+ */
 export const isEditorAltered = atom({
   key: 'isEditorAltered',
   default: false,
@@ -37,13 +41,13 @@ export default function DocumentEditor({ editorRef, content }: EditorProps) {
   const [initialValue, setInitialValue] = useState({})
   const [_, setEditor] = useRecoilState(isEditorAltered);
 
-  // todo - also need to account for title
-  // Store the initial value of the Jots content to compare on changes
+  // Store the initial value of the Jots content on mount
   useEffect(() => {
     setInitialValue(JSON.stringify(content.content))
   }, [])
 
-  function seeChange(event) {
+  // Compare the Jots content from its initial value to determine a change. 
+  function onContentChange(event) {
     if (JSON.stringify(event) === initialValue) {
       setEditor(false)
     } else {
@@ -58,7 +62,7 @@ export default function DocumentEditor({ editorRef, content }: EditorProps) {
           plugins={plugins}
           editorRef={editorRef}
           initialValue={content.content}
-          onChange={seeChange}
+          onChange={onContentChange}
         >
           <FixedToolbar>
             <FixedToolbarButtons />

--- a/components/document-editor.tsx
+++ b/components/document-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { CommentsProvider } from '@udecode/plate-comments';
 import { Plate, PlateProvider } from '@udecode/plate-common';
@@ -15,6 +15,7 @@ import { FloatingToolbar } from '@/components/plate-ui/floating-toolbar';
 import { FloatingToolbarButtons } from '@/components/plate-ui/floating-toolbar-buttons';
 import { MentionCombobox } from '@/components/plate-ui/mention-combobox';
 import { MyValue } from '@/types/plate-types';
+import { atom, useRecoilState } from 'recoil';
 
 interface EditorProps {
   editorRef: any
@@ -26,8 +27,29 @@ interface EditorProps {
   }
 }
 
+export const isEditorAltered = atom({
+  key: 'isEditorAltered',
+  default: false,
+});
+
 export default function DocumentEditor({ editorRef, content }: EditorProps) {
   const containerRef = useRef(null);
+  const [initialValue, setInitialValue] = useState({})
+  const [_, setEditor] = useRecoilState(isEditorAltered);
+
+  // todo - also need to account for title
+  // Store the initial value of the Jots content to compare on changes
+  useEffect(() => {
+    setInitialValue(JSON.stringify(content.content))
+  }, [])
+
+  function seeChange(event) {
+    if (JSON.stringify(event) === initialValue) {
+      setEditor(false)
+    } else {
+      setEditor(true)
+    }
+  }
 
   return (
     <div className="border rounded-md border-gray-400 border-opacity-20 mx-8">
@@ -36,6 +58,7 @@ export default function DocumentEditor({ editorRef, content }: EditorProps) {
           plugins={plugins}
           editorRef={editorRef}
           initialValue={content.content}
+          onChange={seeChange}
         >
           <FixedToolbar>
             <FixedToolbarButtons />

--- a/components/jots/jot-details.tsx
+++ b/components/jots/jot-details.tsx
@@ -6,6 +6,7 @@ import { MyValue } from '@/types/plate-types';
 import DocumentEditor from '../document-editor';
 import { Label, LabelAssociation, User } from '@prisma/client';
 import { JotHeader } from './jot-header';
+import { RecoilRoot } from 'recoil';
 
 interface LabelAssociations extends LabelAssociation {
   label: Label;
@@ -30,20 +31,22 @@ export default function JotDetails({ jot }: JotProps) {
 
   return (
     <div>
-      <JotHeader
-        jot={jot}
-        editorRef={editorRef}
-      />
+      <RecoilRoot>
+        <JotHeader
+          jot={jot}
+          editorRef={editorRef}
+        />
 
-      <DocumentEditor
-        editorRef={editorRef}
-        content={{
-          id: jot.id,
-          title: jot.title,
-          content: jot.content as MyValue,
-          createdAt: jot.createdAt,
-        }}
-      />
+        <DocumentEditor
+          editorRef={editorRef}
+          content={{
+            id: jot.id,
+            title: jot.title,
+            content: jot.content as MyValue,
+            createdAt: jot.createdAt,
+          }}
+        />
+      </RecoilRoot>
     </div>
   );
 }

--- a/components/jots/jot-header.tsx
+++ b/components/jots/jot-header.tsx
@@ -45,16 +45,17 @@ export function JotHeader({ jot, editorRef }: JotProps) {
   const isChanged = useRecoilValue(isEditorAltered);
   useEffect(() => {
     const handleWindowClose = (e) => {
-      if (!isChanged) return
-      e.preventDefault()
-      return (e.returnValue = 'You have unsaved changes - are you sure you wish to leave this page?')
+      if (isChanged || title !== jot.title) {
+        e.preventDefault()
+        return 'You have unsaved changes - are you sure you wish to leave this page?'
+      }
     }
 
     window.addEventListener('beforeunload', handleWindowClose)
     return () => {
       window.removeEventListener('beforeunload', handleWindowClose)
     }
-  }, [isChanged])
+  }, [isChanged, title])
 
   async function save() {
     setIsSaving(true)
@@ -81,6 +82,9 @@ export function JotHeader({ jot, editorRef }: JotProps) {
         variant: "destructive",
       })
     }
+
+    // Title needs set to avoid event listener being triggered on update.
+    jot.title = title
 
     router.refresh()
     setIsSaving(false)
@@ -143,7 +147,7 @@ export function JotHeader({ jot, editorRef }: JotProps) {
           ) : (
             <Icons.save className="mr-2 h-4 w-4" />
           )}
-          <span>{isChanged ? 'Save' : 'Saved'}</span>
+          <span>{isChanged || title !== jot.title ? 'Save' : 'Saved'}</span>
         </Button>
       </PageBreadcrumbs>
 

--- a/components/jots/jot-header.tsx
+++ b/components/jots/jot-header.tsx
@@ -7,13 +7,15 @@ import { buttonVariants } from "../plate-ui/button"
 import { Icons } from "../icons"
 import { UserAvatar } from "../user-avatar"
 import { MyValue } from "@/types/plate-types"
-import { RefObject, useState } from "react"
+import { RefObject, useEffect, useState } from "react"
 import { Button } from "../ui/button"
 import { PlateEditor } from "@udecode/plate-common"
 import { toast } from "../ui/use-toast"
 import { useRouter } from "next/navigation"
 import { Badge } from "../ui/badge"
 import { LabelSelection } from "../label-selection"
+import { useRecoilValue } from "recoil"
+import { isEditorAltered } from "../document-editor"
 
 interface LabelAssociations extends LabelAssociation {
   label: Label;
@@ -38,6 +40,21 @@ export function JotHeader({ jot, editorRef }: JotProps) {
   const router = useRouter()
   const [title, setTitle] = useState(jot.title)
   const [isSaving, setIsSaving] = useState(false)
+
+  // When a user attempts to navigate away with changes, we warn them first.
+  const isChanged = useRecoilValue(isEditorAltered);
+  useEffect(() => {
+    const handleWindowClose = (e) => {
+      if (!isChanged) return
+      e.preventDefault()
+      return (e.returnValue = 'You have unsaved changes - are you sure you wish to leave this page?')
+    }
+
+    window.addEventListener('beforeunload', handleWindowClose)
+    return () => {
+      window.removeEventListener('beforeunload', handleWindowClose)
+    }
+  }, [isChanged])
 
   async function save() {
     setIsSaving(true)
@@ -126,7 +143,7 @@ export function JotHeader({ jot, editorRef }: JotProps) {
           ) : (
             <Icons.save className="mr-2 h-4 w-4" />
           )}
-          <span>Save</span>
+          <span>{isChanged ? 'Save' : 'Saved'}</span>
         </Button>
       </PageBreadcrumbs>
 

--- a/components/templates/template-details.tsx
+++ b/components/templates/template-details.tsx
@@ -6,6 +6,7 @@ import { MyValue } from '@/types/plate-types';
 import DocumentEditor from '../document-editor';
 import { Label, LabelAssociation, User } from '@prisma/client';
 import { TemplateHeader } from './template-header';
+import { RecoilRoot } from 'recoil';
 
 interface LabelAssociations extends LabelAssociation {
   label: Label;
@@ -27,20 +28,22 @@ export default function TemplateDetails({ jotTemplate }: TemplateProps) {
 
   return (
     <div>
-      <TemplateHeader
-        jotTemplate={jotTemplate}
-        editorRef={editorRef}
-      />
+      <RecoilRoot>
+        <TemplateHeader
+          jotTemplate={jotTemplate}
+          editorRef={editorRef}
+        />
 
-      <DocumentEditor
-        editorRef={editorRef}
-        content={{
-          id: jotTemplate.id,
-          title: jotTemplate.title,
-          content: jotTemplate.content as MyValue,
-          createdAt: jotTemplate.createdAt,
-        }}
-      />
+        <DocumentEditor
+          editorRef={editorRef}
+          content={{
+            id: jotTemplate.id,
+            title: jotTemplate.title,
+            content: jotTemplate.content as MyValue,
+            createdAt: jotTemplate.createdAt,
+          }}
+        />
+      </RecoilRoot>
     </div>
   );
 }

--- a/components/ui/breadcrumbs.tsx
+++ b/components/ui/breadcrumbs.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { ChevronRight } from "lucide-react"
 import { cn, getValidChildren } from "@/lib/utils"
+import Link from "next/link"
 
 export interface BreadcrumbProps extends React.ComponentPropsWithoutRef<"nav"> {
   /* The visual separator between each breadcrumb item */
@@ -112,7 +113,7 @@ export const BreadcrumbLink = React.forwardRef<
   HTMLAnchorElement,
   BreadcrumbLinkProps
 >(({ className, as: asComp, isCurrentPage, ...props }, forwardedRef) => {
-  const Comp = (isCurrentPage ? "span" : asComp || "a") as "a"
+  const Comp = (isCurrentPage ? "span" : asComp || Link) as "a"
 
   return (
     <Comp

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "react-lite-youtube-embed": "^2.3.52",
     "react-textarea-autosize": "^8.4.1",
     "react-tweet": "^3.1.1",
+    "recoil": "^0.7.7",
     "shiki": "^0.14.3",
     "slate": "^0.94.1",
     "slate-history": "^0.93.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4624,6 +4624,11 @@ gray-matter@^4.0.3:
     section-matter "^1.0.0"
     strip-bom-string "^1.0.0"
 
+hamt_plus@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
+  integrity sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==
+
 hard-rejection@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/hard-rejection/-/hard-rejection-2.1.0.tgz#1c6eda5c1685c63942766d79bb40ae773cecd883"
@@ -7199,6 +7204,13 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+recoil@^0.7.7:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.7.tgz#c5f2c843224384c9c09e4a62c060fb4c1454dc8e"
+  integrity sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==
+  dependencies:
+    hamt_plus "1.0.2"
 
 redent@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
> [!IMPORTANT]  
> App Router currently does not support native functionality for navigating between the client via their <Link> component. This will only work upon trying to hard refresh the browser which sucks tbh but this sets up the architecture in place for whenever this eventually becomes available or a solution is in place.

- [x] Install recoil
- [x] Add warning to Jot details page on unsaved data
- [x] Add warning to Template details page on unsaved data
- [x] Add text change to button
