### PR TITLE
fix: Upgrade Prisma Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@auth/prisma-adapter": "^2.0.0",
     "@hookform/resolvers": "^3.1.0",
-    "@prisma/client": "^5.12.1",
+    "@prisma/client": "^5.14.0",
     "@radix-ui/react-accessible-icon": "^1.0.2",
     "@radix-ui/react-accordion": "^1.1.1",
     "@radix-ui/react-alert-dialog": "^1.0.3",
@@ -107,7 +107,7 @@
     "prettier": "^2.8.8",
     "prettier-plugin-tailwindcss": "^0.2.1",
     "pretty-quick": "^3.1.3",
-    "prisma": "5.2.0",
+    "prisma": "5.4.0",
     "rehype": "^12.0.1",
     "rehype-autolink-headings": "^6.1.1",
     "rehype-pretty-code": "^0.9.5",


### PR DESCRIPTION
Closes #275

Patch generated by `qwen3.6-35b-a3b via local API`.